### PR TITLE
(consideration) Remove PII from user key

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
       var user = {
         "key": "example-user-key",
         "name": "Sandy"
-        }
       };
 
       var div = document.createElement("div");

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <body>
     <script>
       var user = {
-        "key": "00000000-0000-0000-0000-000000000000",
+        "key": "example-user-key",
         "email": "bob@example.com",
         "firstName": "Bob",
         "lastName": "Loblaw",

--- a/index.html
+++ b/index.html
@@ -8,9 +8,10 @@
   <body>
     <script>
       var user = {
+        "key": "00000000-0000-0000-0000-000000000000",
+        "email": "bob@example.com",
         "firstName": "Bob",
         "lastName": "Loblaw",
-        "key": "bob@example.com",
         "custom": {
           "groups": "beta_testers"
         }

--- a/index.html
+++ b/index.html
@@ -9,11 +9,7 @@
     <script>
       var user = {
         "key": "example-user-key",
-        "email": "bob@example.com",
-        "firstName": "Bob",
-        "lastName": "Loblaw",
-        "custom": {
-          "groups": "beta_testers"
+        "name": "Sandy"
         }
       };
 


### PR DESCRIPTION
Using an email as the user's key sets a poor example.
- PII should not be used as a user's key.
- A user's key should be something that doesn't change, and a user's email could change.