### PR TITLE
Adding IE javascript compatibility tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge;chrome=1">
     <title>LaunchDarkly tutorial</title>
     <script src="https://unpkg.com/launchdarkly-js-client-sdk@2"></script>
   </head>


### PR DESCRIPTION
The inclusion of this tag fixes compatibility issues with the `hello-js` app in IE11.