### PR TITLE
Update hello-js to use @launchdarkly/js-client-sdk v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ We've built a simple browser application that demonstrates how LaunchDarkly's SD
 
 Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [JavaScript SDK reference guide](https://docs.launchdarkly.com/sdk/client-side/javascript).
 
+This version of the application uses the [LaunchDarkly JavaScript SDK v4](https://github.com/launchdarkly/js-core/tree/main/packages/sdk/browser) (`@launchdarkly/js-client-sdk`).
+
 #### Build instructions 
 
 1. Edit `index.html` and set the value of `clientSideID` to your LaunchDarkly client-side ID. If there is an existing boolean feature flag in your LaunchDarkly project that you want to evaluate, set `flagKey` to the flag key.

--- a/index.html
+++ b/index.html
@@ -4,12 +4,13 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge;chrome=1">
     <title>LaunchDarkly tutorial</title>
-    <script src="https://unpkg.com/launchdarkly-js-client-sdk@3"></script>
     <link rel="stylesheet" href="./index.css">
   </head>
   <body>
-    <script>
-    function main()
+    <script type="module">
+    import { createClient } from 'https://unpkg.com/@launchdarkly/js-client-sdk@4/dist/index.js';
+
+    async function main()
     {
       // Set clientSideID to your LaunchDarkly client-side ID
       const clientSideID = '';
@@ -34,23 +35,23 @@
         return;
       }
 
-      const ldclient = LDClient.initialize(clientSideID, context);
+      const ldclient = createClient(clientSideID, context);
 
       function render() {
         const flagValue = ldclient.variation(flagKey, false);
-      const label = `The ${flagKey} feature flag evaluates to ${flagValue}.`;
-      document.body.style.background = flagValue ? '#00844B' : '#373841';
+        const label = `The ${flagKey} feature flag evaluates to ${flagValue}.`;
+        document.body.style.background = flagValue ? '#00844B' : '#373841';
         div.replaceChild(document.createTextNode(label), div.firstChild);
       }
 
-      ldclient.on('initialized', () => {
-        div.replaceChild(document.createTextNode('SDK successfully initialized!'), div.firstChild);
-      });
-      ldclient.on('failed', () => {
-        div.replaceChild(document.createTextNode('SDK failed to initialize'), div.firstChild);
-      });
-      ldclient.on('ready', render);
       ldclient.on('change', render);
+
+      const result = await ldclient.start();
+      if (result.status === 'complete') {
+        render();
+      } else {
+        div.replaceChild(document.createTextNode('SDK failed to initialize'), div.firstChild);
+      }
     }
     main();
     </script>


### PR DESCRIPTION
## Summary

Migrates the hello-js example application from `launchdarkly-js-client-sdk@3` to `@launchdarkly/js-client-sdk@4`.

Key changes:
- **Module loading**: Replaced the global `<script src="...@3">` tag with a `<script type="module">` using an ESM import from unpkg
- **Initialization API**: Replaced `LDClient.initialize(clientSideID, context)` with `createClient(clientSideID, context)` + `await client.start()`
- **Init handling**: Replaced event-based initialization (`on('initialized')`, `on('failed')`, `on('ready')`) with the promise-based `start()` result pattern
- **Live updates**: Preserved `on('change', render)` for reacting to flag changes
- Also fixes minor indentation inconsistency in the `render()` function that existed in the original

## Review & Testing Checklist for Human

- [ ] **Open `index.html` in a browser with a real `clientSideID` set** and verify the SDK initializes, evaluates the flag, and displays the result. This was not tested during development.
- [ ] **Verify live flag updates work**: Toggle the flag value in LaunchDarkly and confirm the page updates without a refresh (the `on('change', render)` listener).
- [ ] **Verify the ESM import from unpkg resolves correctly** in target browsers — `<script type="module">` with a bare unpkg URL. Confirm no CORS or module resolution issues.
- [ ] **Confirm `start()` behavior on failure**: Set an invalid `clientSideID` and verify the "SDK failed to initialize" message appears (the `else` branch).

### Notes
- The v4 SDK (`@launchdarkly/js-client-sdk`) only ships ESM and CJS bundles (no UMD/IIFE), so the example now requires `<script type="module">` instead of a classic script tag. This means it won't work in very old browsers that don't support ES modules.
- Link to Devin session: https://app.devin.ai/sessions/c889568b4c3b4e96bfedd880004c9291
- Requested by: @joker23
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/hello-js/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
